### PR TITLE
Fix github content bug

### DIFF
--- a/packages/mdx-preview-extension/esbuild.js
+++ b/packages/mdx-preview-extension/esbuild.js
@@ -5,6 +5,7 @@ build({
     entryPoints: {
         popup: "./src/popup.tsx",
         content: "./src/content.ts",
+        injectScript: './src/injectScript.ts'
     },
     bundle: true,
     outdir: './build',

--- a/packages/mdx-preview-extension/public/manifest.json
+++ b/packages/mdx-preview-extension/public/manifest.json
@@ -32,5 +32,11 @@
                 "content.js"
             ]
         }
-    ]
+    ],
+    "web_accessible_resources":[{
+        "resources": ["injectScript.js"],
+        "matches": [
+            "https://*.github.com/*"
+        ]
+    }]
 }

--- a/packages/mdx-preview-extension/src/Popup/App.tsx
+++ b/packages/mdx-preview-extension/src/Popup/App.tsx
@@ -4,6 +4,29 @@ import { Msg } from "../types";
 export default function App() {
     const [extensionMessage, setExtensionMessage] = useState('Loading Mdx Preview')
 
+    async function injectScripts (){
+        let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        await chrome.scripting.executeScript({
+        target: { tabId: tab.id! },
+        func:  () => {
+            const pth = 'injectScript.js';
+            const id = 'inject-script'
+            const script = document.createElement('script');
+            script.id = id;
+            script.src = chrome.runtime.getURL(pth);
+            if(!document.getElementById(id)){
+                (document.head || document.documentElement).appendChild(script)
+                script.onload = ()=>{
+                    window.postMessage({type: Msg.EXTENSION_ACTIVATED})
+                }
+            }else{
+                window.postMessage({type: Msg.EXTENSION_ACTIVATED})
+            }
+           
+        },
+        });
+    }
+
     useEffect(()=>{
         chrome.runtime.onMessage.addListener((request)=>{
             if(request.type === Msg.INVALID_PAGE){
@@ -11,11 +34,7 @@ export default function App() {
             }
         })
 
-        chrome.tabs.query({currentWindow: true, active: true}, function (tabs){
-            var activeTab = tabs[0];
-            if(activeTab.id)
-            chrome.tabs.sendMessage(activeTab.id, {type: Msg.EXTENSION_ACTIVATED});
-        });
+        injectScripts();
     },[])
   return <h1>{extensionMessage}</h1>;
 }

--- a/packages/mdx-preview-extension/src/content.ts
+++ b/packages/mdx-preview-extension/src/content.ts
@@ -1,27 +1,39 @@
 import { Msg } from "./types";
-import { GITHUB_EDIT_TAB_SELECTOR, getTextContentWithFormatting, injectAddPreviewDiv, isGithubEditsPage } from "./utils";
+import { GITHUB_EDIT_TAB_SELECTOR, injectPreviewDivFromBlob, injectPreviewDivFromEdit, isGithubMdxPage } from "./utils";
 
 let timeoutId: NodeJS.Timeout;
 const processPage = async () => {
-  const isGithubPage = isGithubEditsPage(window.location.href)
-  if (isGithubPage.isValid) {
+  const isGithubPage = isGithubMdxPage(window.location.href)
+  if (isGithubPage.isValid && isGithubPage.isEditPage) {
+    const sourceDiv = document.querySelector(GITHUB_EDIT_TAB_SELECTOR)
+      sourceDiv!.dispatchEvent(new CustomEvent(Msg.GET_EDITOR_DATA, {
+        bubbles: true
+      }))
+
+    window.postMessage({type: Msg.GET_EDITOR_DATA})
+
     const observer = new MutationObserver(handleContentUpdate)
     const observerConfig = {
       characterData: true,
       childList: true,
       subtree: true
     }
-    const sourceDiv = document.querySelector(GITHUB_EDIT_TAB_SELECTOR)
     observer.observe(sourceDiv!, observerConfig)
-    injectAddPreviewDiv(getTextContentWithFormatting(sourceDiv))
+  }else if(isGithubPage.isValid && !isGithubPage.isEditPage){
+    const divId = 'copilot-button-positioner'
+    const docDiv = document.getElementById(divId)
+    const textAreaContent = docDiv!.querySelector('textarea')!.value
+    injectPreviewDivFromBlob(textAreaContent)
   }else{
     await chrome.runtime.sendMessage({type: Msg.INVALID_PAGE, message: isGithubPage.message});
   }
 }
 
-chrome.runtime.onMessage.addListener((request) => {
-  if (request.type === Msg.EXTENSION_ACTIVATED) {
+window.addEventListener('message', (event) => {
+  if (event.data.type === Msg.EXTENSION_ACTIVATED) {
     processPage()
+  }else if(event.data.type === Msg.EDITOR_DATA) {
+    injectPreviewDivFromEdit(event.data.data)
   }
 })
 
@@ -29,10 +41,7 @@ const handleContentUpdate = (mutations: MutationRecord[]) => {
   mutations.forEach((mutation) => {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(()=>{
-      const sourceDiv = document.querySelector(GITHUB_EDIT_TAB_SELECTOR)
-      injectAddPreviewDiv(getTextContentWithFormatting(sourceDiv))
+      window.postMessage({type: Msg.GET_EDITOR_DATA})
     }, 1000)
   })
 }
-
-export { };

--- a/packages/mdx-preview-extension/src/injectScript.ts
+++ b/packages/mdx-preview-extension/src/injectScript.ts
@@ -1,0 +1,9 @@
+import { EditorContent, Msg } from "./types";
+import { GITHUB_EDIT_TAB_SELECTOR } from "./utils";
+
+window.addEventListener('message', (event) => {
+    if (event.data.type === Msg.GET_EDITOR_DATA) {
+        const editorElement = document.querySelector(GITHUB_EDIT_TAB_SELECTOR) as any as EditorContent
+        window.postMessage({ type: Msg.EDITOR_DATA, data: editorElement.cmView.view.state.doc.toString()})
+    }
+})

--- a/packages/mdx-preview-extension/src/types.ts
+++ b/packages/mdx-preview-extension/src/types.ts
@@ -2,7 +2,9 @@ export enum Msg {
     EXTENSION_ACTIVATED = 'extension_activated',
     INVALID_PAGE = 'invalid_page',
     MDX_DATA = 'mdx_data',
-    CONFIG_DATA = 'config_data'
+    CONFIG_DATA = 'config_data',
+    GET_EDITOR_DATA = 'get_editor_data',
+    EDITOR_DATA = 'editor_data'
 }
 
 export interface GithubRepoData {
@@ -10,4 +12,29 @@ export interface GithubRepoData {
     repo: string,
     branch: string,
     path: string
+}
+
+export interface EditorContent {
+    cmView: {
+        view: {
+            state: {
+                doc: {
+                    lineAt: (pos: number) => {
+                        number: number;
+                        from: number;
+                        text: string;
+                    };
+                };
+                selection: {
+                    main: {
+                        from: number;
+                        to: number;
+                        head: number;
+                    };
+                };
+                sliceDoc: (from: number, to: number) => string;
+            };
+            dispatch: (changes: any) => void;
+        };
+    };
 }

--- a/packages/mdx-preview-extension/src/utils.ts
+++ b/packages/mdx-preview-extension/src/utils.ts
@@ -6,71 +6,78 @@ export const GITHUB_EDIT_TAB_SELECTOR = 'div.cm-content'
 const EMBED_IFRAME_ID = 'fable-embed-iframe'
 const IFRAME_URL = 'http://localhost:5173/'
 const githubMDXPageRegex = /github\.com\/.*\/edit\/.*\.mdx$/;
-const githubEditsPageRegex = /github\.com\/([^\/]+)\/([^\/]+)\/edit\/([^\/]+)\/(.+)/;
+const githubBlobPageRegex = /github\.com\/.*\/blob\/.*\.mdx$/;
+const githubEditsPageRegex = /github\.com\/([^\/]+)\/([^\/]+)\/(edit|blob)\/([^\/]+)\/(.+)/;
 
-export const isGithubEditsPage = (url: string): { isValid: boolean, message: string } => {
+export const isGithubMdxPage = (url: string): { isValid: boolean, message: string, isEditPage: boolean } => {
 
-    if (!githubMDXPageRegex.test(url)) {
+    if (githubMDXPageRegex.test(url)) {
         return {
-            isValid: false,
-            message: 'This is not a mdx file, open mdx file in github to preview'
+            isValid: true,
+            isEditPage: true,
+            message: 'Loading Mdx preview'
+        }
+    }
+
+    if(githubBlobPageRegex.test(url)){
+        return {
+            isValid: true,
+            isEditPage: false,
+            message: 'Loading Mdx preview'
         }
     }
 
     return {
-        isValid: true,
-        message: 'Loading Mdx preview'
+        isValid: false,
+        isEditPage: false,
+        message: 'This is not a mdx file, open mdx file in github to preview'
     }
 }
 
-export const injectAddPreviewDiv = async (data: string) => {
+export const injectPreviewDivFromEdit = async (data: string) => {
     const headingElement = document.querySelector('h1[data-testid="screen-reader-heading"]');
     if (headingElement && headingElement.parentElement) {
         const lastChild = headingElement.parentElement.lastElementChild;
-        let newChild = document.getElementById(NEW_ELEMENT_ID)
-
-        if (!document.getElementById(NEW_ELEMENT_ID)) {
-            const botData = await getManifestAndConfig();
-            newChild = document.createElement('div');
-            newChild.style.flex = '1'
-            newChild.style.border = '1px solid rgb(48, 54, 61)'
-            newChild.style.borderRadius = '6px'
-            newChild.style.backgroundColor = 'rgb(13, 17, 23)'
-            newChild.id = NEW_ELEMENT_ID
-
-            const iframe = document.createElement('iframe');
-            iframe.src = IFRAME_URL
-            iframe.height = '100%'
-            iframe.width = '100%'
-            iframe.id = EMBED_IFRAME_ID
-            newChild!.appendChild(iframe);
-            lastChild!.appendChild(newChild!);
-            iframe.onload = () => {
-                iframe.contentWindow?.postMessage({ type: Msg.CONFIG_DATA, data: botData}, '*')
-                iframe.contentWindow?.postMessage({ type: Msg.MDX_DATA, data: data }, '*')
-            }
-        } else {
-            let iframe = document.getElementById(EMBED_IFRAME_ID) as HTMLIFrameElement;
-            iframe.contentWindow?.postMessage({ type: Msg.MDX_DATA, data: data }, '*')
-        }
+       injectAddPreviewDiv(data, lastChild!);
     }
 }
 
-export function getTextContentWithFormatting(element: Element | null) {
-    if (!element) {
-        return ''
-    }
-    const lines = []
-    const walker = document.createTreeWalker(element, NodeFilter.SHOW_ELEMENT, null);
+export const injectPreviewDivFromBlob = async (data: string) => {
+    const rootParentDiv = document.querySelector('div[data-selector="repos-split-pane-content"]');
+    const lastChild = rootParentDiv!.lastElementChild!.lastElementChild;
+    await injectAddPreviewDiv(data, lastChild!)
 
-    while (walker.nextNode()) {
-        const currentNode = walker.currentNode as Element;
-        if (currentNode.classList.contains('cm-line')) {
-            lines.push('\n' + currentNode.textContent)
+}
+
+const injectAddPreviewDiv = async (data: string, lastChild: Element) => {
+    let newChild = document.getElementById(NEW_ELEMENT_ID)
+    if (!newChild) {
+        const botData = await getManifestAndConfig();
+
+        (lastChild.lastElementChild! as HTMLElement).style.flexBasis = '100%'
+
+        newChild = document.createElement('div');
+        newChild.style.flexBasis = '100%'
+        newChild.style.border = '1px solid rgb(48, 54, 61)'
+        newChild.style.borderRadius = '6px'
+        newChild.style.backgroundColor = 'rgb(13, 17, 23)'
+        newChild.id = NEW_ELEMENT_ID
+
+        const iframe = document.createElement('iframe');
+        iframe.src = IFRAME_URL
+        iframe.height = '100%'
+        iframe.width = '100%'
+        iframe.id = EMBED_IFRAME_ID
+        newChild!.appendChild(iframe);
+        lastChild.appendChild(newChild!);
+        iframe.onload = () => {
+            iframe.contentWindow?.postMessage({ type: Msg.CONFIG_DATA, data: botData}, '*')
+            iframe.contentWindow?.postMessage({ type: Msg.MDX_DATA, data: data }, '*')
         }
+    } else {
+        let iframe = document.getElementById(EMBED_IFRAME_ID) as HTMLIFrameElement;
+        iframe.contentWindow?.postMessage({ type: Msg.MDX_DATA, data: data }, '*')
     }
-
-    return lines.join('');
 }
 
 const getManifestAndConfig = async () => {
@@ -85,8 +92,8 @@ const getGithubRepoData = ()=>{
   const githubRepoData : GithubRepoData = {
     owner: match![1],
     repo: match![2],
-    branch: match![3],
-    path: './'+match![4]
+    branch: match![4],
+    path: './'+match![5]
   }
   return githubRepoData;
 }
@@ -95,7 +102,6 @@ const API_URL = "http://localhost:3000"
 const githubBotApiCall = async () => {
 
   const repoData = getGithubRepoData();
-
   const res = await fetch(`${API_URL}/hello-world?owner=${repoData.owner}&repo=${repoData.repo}&branch=${repoData.branch}&relFilePath=${encodeURIComponent(repoData.path)}`)
 
   const data = await res.json();


### PR DESCRIPTION
In the /edit page of github only partial code is extracted by extension because dom clips the extra content. To solve this, changes are made so it directly takes content from codemirror instance.